### PR TITLE
Change documentation to use underscore instead of dashes in folder naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ dotnet new -u Popov1024.HttpApi.Template.CSharp
 ## Using
 Make some dir:
 ```
-mkdir my-api-project
-cd my-api-project
+mkdir my_api_project
+cd my_api_project
 ```
 
 Create solution:


### PR DESCRIPTION
This stops an issue when following the documentation when running docker-compose since the script generator for the .yml file inserts underscores not dashes.